### PR TITLE
[S63] Feature: Azure Cloud account linking with Minimal Permissions

### DIFF
--- a/scripts/azure-account-link.sh
+++ b/scripts/azure-account-link.sh
@@ -50,7 +50,7 @@ if [ $? -ne 0 ]; then
 fi
 
 az role definition create --role-definition '{
-  "Name": "CustomMinimalRole",
+  "Name": "facets-'"$PRINCIPAL_NAME"'",
   "Description": "Custom role with minimal permissions",
   "Actions": [
     "Microsoft.Resources/subscriptions/resourceGroups/*",
@@ -67,7 +67,7 @@ az role definition create --role-definition '{
   "AssignableScopes": [
     "/subscriptions/'"$SUBSCRIPTION_ID"'"
   ]
-}' &>/dev/null
+}'
 
 if [ $? -ne 0 ]; then
     echo "Failed to create role definition."
@@ -75,7 +75,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Create the Service Principal with Custom role that has minimal permissions
-SP_JSON=$(az ad sp create-for-rbac --name "facets-$PRINCIPAL_NAME" --role CustomMinimalRole --scopes /subscriptions/"$SUBSCRIPTION_ID")
+SP_JSON=$(az ad sp create-for-rbac --name "facets-$PRINCIPAL_NAME" --role "facets-$PRINCIPAL_NAME" --scopes /subscriptions/"$SUBSCRIPTION_ID")
 
 
 if [ $? -ne 0 ]; then

--- a/scripts/azure-account-link.sh
+++ b/scripts/azure-account-link.sh
@@ -49,8 +49,34 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Create the Service Principal with Owner role
-SP_JSON=$(az ad sp create-for-rbac --name "facets-$PRINCIPAL_NAME" --role Owner --scopes /subscriptions/"$SUBSCRIPTION_ID")
+az role definition create --role-definition '{
+  "Name": "CustomMinimalRole",
+  "Description": "Custom role with minimal permissions",
+  "Actions": [
+    "Microsoft.Resources/subscriptions/resourceGroups/*",
+    "Microsoft.Network/virtualNetworks/*",
+    "Microsoft.Network/networkSecurityGroups/*",
+    "Microsoft.Network/publicIPAddresses/*",
+    "Microsoft.Network/natGateways/*",
+    "Microsoft.ContainerService/*",
+    "Microsoft.Storage/storageAccounts/*",
+    "Microsoft.Authorization/roleAssignments/*",
+    "Microsoft.Network/privateDnsZones/*",
+    "Microsoft.DBforMySQL/flexibleServers/*"
+  ],
+  "AssignableScopes": [
+    "/subscriptions/'"$SUBSCRIPTION_ID"'"
+  ]
+}' &>/dev/null
+
+if [ $? -ne 0 ]; then
+    echo "Failed to create role definition."
+    exit 1
+fi
+
+# Create the Service Principal with Custom role that has minimal permissions
+SP_JSON=$(az ad sp create-for-rbac --name "facets-$PRINCIPAL_NAME" --role CustomMinimalRole --scopes /subscriptions/"$SUBSCRIPTION_ID")
+
 
 if [ $? -ne 0 ]; then
     echo "Failed to create Service Principal."


### PR DESCRIPTION
## Tests

### Create Azure Account with updated script
Used the script locally to link Azure account with SaaS CP
![image](https://github.com/user-attachments/assets/8491008f-da85-457c-a4ee-7d9eb09e4295)
![image](https://github.com/user-attachments/assets/8b041de9-e528-4940-8ed6-2b676494ac40)
![image](https://github.com/user-attachments/assets/9706b4a2-27df-407b-9f55-0dcf24a7c449)
![image](https://github.com/user-attachments/assets/71ce40d0-fd0d-4dfa-8e90-0f88e082ce57)

### Launch
Launched env with all Azure resources enabled
Release URL  - https://demo.control-plane-saas-cp-saas-dev.console.facets.cloud/capc/min-permission-test-demo/cluster/66ced250abfbb20007c30e10/release-details/66cf66753747c600060e1b3e 

![image](https://github.com/user-attachments/assets/8f2b154f-f445-4796-9caa-ac24deb43fae)
![image](https://github.com/user-attachments/assets/ce1107cd-f37e-42e0-8750-b9d2b7072e94)

### Destroy
Release URL - https://demo.control-plane-saas-cp-saas-dev.console.facets.cloud/capc/min-permission-test-demo/cluster/66ced250abfbb20007c30e10/release-details/66cf6f6d3747c600060e1b61
![image](https://github.com/user-attachments/assets/52045ffb-c0b2-48b2-918a-cab3a079393d)
