### PR TITLE
fix gcp role name

### DIFF
--- a/scripts/gcp-account-link.sh
+++ b/scripts/gcp-account-link.sh
@@ -10,7 +10,7 @@ CP_URL=$1
 ACCOUNT_NAME="$2"
 # Concatenate "facets-" with the provided principal name
 PRINCIPAL_NAME="facets-$2"
-ROLE_NAME="facets_$2"
+ROLE_NAME=$(echo $PRINCIPAL_NAME | tr '-' '_')
 
 WEBHOOK_ID=$3
 


### PR DESCRIPTION
gcp has role name constraints
`It doesn't match pattern "[a-zA-Z0-9_\.]{3,64}". The role_id must be 3 to 64 characters long and can be a mix of uppercase and lowercase English letters, digits, underscores and periods`

the ui allows hyphens, hence we need to replace them with underscores

current error:
<img width="1705" alt="image" src="https://github.com/user-attachments/assets/527d8e0e-37db-47c1-9382-cadd30aa2615">

with new change:
<img width="528" alt="image" src="https://github.com/user-attachments/assets/540d1850-46ae-40d2-af76-0030120c274e">
