### PR TITLE
added quick fix to add the removed attributes back

### DIFF
--- a/docs/output_lookup_tree.json
+++ b/docs/output_lookup_tree.json
@@ -68,7 +68,9 @@
     "aws_efs": {
         "out": {
             "attributes": {
-                "topics": {}
+                "topics": {},
+                "storage_class_name": {},
+                "file_system_id": {}
             }
         }
     },


### PR DESCRIPTION
the issue was caught in simplismart as the last doc update removed below attributes
![image](https://github.com/user-attachments/assets/5b9a1a84-6a6b-404f-a1d2-6f27ec538570)
